### PR TITLE
FasterCSV bombs under Ruby 1.9.2; here's a simple workaround

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fech (0.1.4)
+    fech (0.1.5)
       fastercsv
       people
 

--- a/lib/fech.rb
+++ b/lib/fech.rb
@@ -6,6 +6,7 @@ require 'fech/translator'
 require 'fech/mapped'
 require 'fech/fech_utils'
 require 'fech/map_generator'
+require 'fech/csv'
 
 module Fech
   extend FechUtils

--- a/lib/fech/csv.rb
+++ b/lib/fech/csv.rb
@@ -1,0 +1,12 @@
+require 'fastercsv' unless RUBY_VERSION > '1.9'
+require 'csv'       if     RUBY_VERSION > '1.9'
+
+module Fech
+  begin
+    class Csv < CSV
+    end
+  rescue
+    class Csv < FasterCSV
+    end
+  end
+end

--- a/lib/fech/filing.rb
+++ b/lib/fech/filing.rb
@@ -1,6 +1,5 @@
 require 'tmpdir'
 require 'open-uri'
-require 'fastercsv'
 
 module Fech
   
@@ -192,9 +191,9 @@ module Fech
     def parse_filing_version
       first = File.open(file_path).first
       if first.index("\034").nil?
-        FasterCSV.parse(first).flatten[2]
+        Fech::Csv.parse(first).flatten[2]
       else
-        FasterCSV.parse(first, :col_sep => "\034").flatten[2]
+        Fech::Csv.parse(first, :col_sep => "\034").flatten[2]
       end
     end
     
@@ -224,7 +223,7 @@ module Fech
         raise "File #{file_path} does not exist. Try invoking the .download method on this Filing object."
       end
       c = 0
-      FasterCSV.foreach(file_path, :col_sep => delimiter, :skip_blanks => true) do |row|
+      Fech::Csv.foreach(file_path, :col_sep => delimiter, :skip_blanks => true) do |row|
         if opts[:with_index]
           yield [row, c]
           c += 1

--- a/lib/fech/map_generator.rb
+++ b/lib/fech/map_generator.rb
@@ -40,7 +40,7 @@ module Fech
       # exists for it. If maps for two different versions are identical, they
       # are combined.
       FILING_VERSIONS.each do |version|
-        FasterCSV.foreach(version_summary_file(source_dir, version)) do |row|
+        Fech::Csv.foreach(version_summary_file(source_dir, version)) do |row|
           # Each row of a version summary file contains the ordered list of
           # column names.
           data[row.first] ||= {}

--- a/lib/fech/version.rb
+++ b/lib/fech/version.rb
@@ -1,3 +1,3 @@
 module Fech
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
`FasterCSV` refuses to work under 1.9.2 and asks you to use `CSV` instead.  I added a `Fech::Csv` class that inherits either `FasterCSV` or `CSV` depending on `RUBY_VERSION`.

Tested (manually, no new specs) under 1.8.7 and 1.9.2 on Ubuntu 10.04 LTS.

Note:  The Ruby 1.9 `CSV` lib is equivalent to 1.8's `FasterCSV` so none of the function calls had to be changes.
