### PR TITLE
only date-convert actual date fields 

### DIFF
--- a/lib/fech/default_translations.rb
+++ b/lib/fech/default_translations.rb
@@ -68,11 +68,7 @@ module Fech
       # only convert fields whose name is date* or *_date*
       # lots of other things might be 8 digits, and we have to exclude eg 'candidate'
       t.convert :field => /(^|_)date/ do |value|
-        if /^\d{8}$/.match(value).nil?
-          value
-        else
-          Date.parse(value)
-        end
+        Date.parse(value) rescue value
       end
     end
     


### PR DESCRIPTION
… and not e.g. transaction IDs that happen to be 8 digits

(Example that will fail with previous version: FEC ID 100003 line 616.)
