### PR TITLE
Ensure filing's have access to a translator, regardless of whether it was initialized with one

### DIFF
--- a/lib/fech/filing.rb
+++ b/lib/fech/filing.rb
@@ -13,7 +13,7 @@ module Fech
     # note that there are plenty of <v3 filings after this, so readable? still needs to be checked
     FIRST_V3_FILING = 11850 
     
-    attr_accessor :filing_id, :download_dir, :translator
+    attr_accessor :filing_id, :download_dir
 
     # Create a new Filing object, assign the download directory to system's
     # temp folder by default.
@@ -172,6 +172,15 @@ module Fech
       Fech::Mappings.for_row(row_type, opts)
     end
     
+    # Accessor for @translator. Will return the Translator initialized in
+    # Filing's initializer if built-in translations were passed to Filing's
+    # initializer ({:translate => [:foo, :bar]}).
+    # Otherwise, will create and memoize a new Translator without any default
+    # translations.
+    def translator
+      @translator ||= Fech::Translator.new
+    end
+
     # @yield [t] returns a reference to the filing's Translator
     # @yieldparam [Translator] the filing's Translator
     def translate(&block)

--- a/spec/filing_spec.rb
+++ b/spec/filing_spec.rb
@@ -212,6 +212,38 @@ describe Fech::Filing do
     end
     
   end
+
+  describe "#translator" do
+
+    describe "when Filing was initialized with built-in translations" do
+
+      before do
+        @translated_filing = Fech::Filing.new(723604, :translate => [:names])
+        @translator = @translated_filing.translator
+      end
+
+      it "returns the Translator created in Filing's initializer" do
+        @translated_filing.translator.should == @translator
+        @translated_filing.translator.translations.size.should > 0
+      end
+
+    end
+
+    describe "when Filing was not initialized with built-in translation" do
+
+      before do
+        @untranslated_filing = Fech::Filing.new(723604)
+      end
+
+      it "creates a new Translator with no default ranslations" do
+        @untranslated_filing.translator.should_not be_nil
+        @untranslated_filing.translator.class.should == Fech::Translator
+        @untranslated_filing.translator.translations.should be_empty
+      end
+
+    end
+
+  end
   
   describe "#map" do
     


### PR DESCRIPTION
Changed Fech::Filing#translator from being an attr_accessor to a memoization method. This ensure that a Translator is available to all filings by calling #translator on a Filing instance, even if one wasn't created when the Filing was instantiated.

This guards against a bug where a Filing is initially created without any default translations, but one later attempts to add an ad hoc translation by calling `filing#translate`, or by accessing the translator directly with `filing#translator`.
