### PR TITLE
Check ruby platform for debugger dependencies

### DIFF
--- a/fech.gemspec
+++ b/fech.gemspec
@@ -23,17 +23,23 @@ Gem::Specification.new do |s|
   s.add_dependency "fastercsv"
   s.add_dependency "people"
   s.add_dependency "ensure-encoding"
-  if RUBY_VERSION < "1.9"
-    s.add_development_dependency "linecache", "0.43"
-    s.add_development_dependency "ruby-debug"
-    s.add_development_dependency "iconv"
-  end
-  if RUBY_VERSION >= "2.0"
-    s.add_development_dependency "debugger", "1.4.0"
-  end
-  if RUBY_VERSION >= "1.9" && RUBY_VERSION < '2.0'
-    s.add_development_dependency "ruby-debug19"
-    s.add_development_dependency "linecache19"
+  if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
+    s.add_development_dependency 'rubinius-compiler'
+    s.add_development_dependency 'rubinius-debugger'
+    s.add_development_dependency 'rubysl'
+    s.add_development_dependency 'ffi'
+    s.add_development_dependency 'psych'
+  else
+    if RUBY_VERSION < "1.9"
+      s.add_development_dependency "linecache", "0.43"
+      s.add_development_dependency "ruby-debug"
+      s.add_development_dependency "iconv"
+    elsif RUBY_VERSION >= "2.0"
+      s.add_development_dependency "debugger", "1.4.0"
+    elsif RUBY_VERSION >= "1.9" && RUBY_VERSION < '2.0'
+      s.add_development_dependency "ruby-debug19"
+      s.add_development_dependency "linecache19"
+    end
   end
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 2.6"


### PR DESCRIPTION
@dwillis 

Run under rubinius 2.5.2:

```
$ rake fech:test:spec
................................................................................

Top 10 slowest examples:
  Fech::Comparison compare should return a hash of columns and values that have changed for two filings
    5.9 seconds ./spec/comparison_spec.rb:14
  Fech::Comparison compare should return an array of schedule items that have changed
    4.49 seconds ./spec/comparison_spec.rb:19
  Fech::MapGenerator.convert_header_file_to_row_files should not raise error
    0.87009 seconds ./spec/map_generator_spec.rb:41
  Fech::Filing#rows_like should return only rows matching the specified regex
    0.50275 seconds ./spec/filing_spec.rb:112
  Fech::Comparison compare should return an empty array of schedule items when none have changed
    0.38279 seconds ./spec/comparison_spec.rb:24
  Fech::DefaultTranslations.names should split an aggregate name into its component parts
    0.37312 seconds ./spec/default_translations_spec.rb:38
  Fech::Filing#summary should return the mapped summary row
    0.14522 seconds ./spec/filing_spec.rb:64
  Fech::Translator.combine should correctly compute derived fields
    0.11893 seconds ./spec/translator_spec.rb:72
  Fech::Translator.combine should allow indexing by aliased field names
    0.10866 seconds ./spec/translator_spec.rb:89
  Fech::DefaultTranslations.names should combine name components into aggregate name fields
    0.07169 seconds ./spec/default_translations_spec.rb:28

Finished in 14.15 seconds
80 examples, 0 failures
```