### PR TITLE
Read filing's contents using specified encoding

### DIFF
--- a/lib/fech/filing.rb
+++ b/lib/fech/filing.rb
@@ -246,7 +246,7 @@ module Fech
 
     # The raw contents of the Filing
     def file_contents
-      File.open(file_path, 'r')
+      File.open(file_path, "r:#{@encoding}")
     end
 
     # Determine the form type of the filing

--- a/spec/data/1247604.fec
+++ b/spec/data/1247604.fec
@@ -1,0 +1,58 @@
+HDRFEC8.2FECfile8.2.0.0(f31)
+F3NC00670364Friends of Susan BoserP.O. Box 2056IndianaPA15701PA15Q22018042620180630BradyDavidMr.2018071519909.080.0019909.0835056.580.0035056.582801.190.0020500.0010047.916555.0316602.940.00591.492714.6519909.080.006500.000.006500.000.000.0026409.0835056.580.000.000.000.000.000.000.000.000.0035056.5811448.6926409.0837857.7735056.582801.1922904.830.0022904.8344376.830.0044376.8311557.378041.3219598.690.00591.492714.6522904.830.0020500.000.0020500.000.000.0043404.8344376.830.000.000.000.000.000.000.000.000.0044376.83
+SA11AIC00670364SA11AI.4279INDAaronRoger339 Liberty StreetFranklinPA16323G201820180522250.00250.00Check received by mailUnknownUnknown
+SA11AIC00670364SA11AI.4291INDArmbrustGary225 Heasley Hollow RoadVandergriftPA15690P201820180510150.00300.00Check received by mailSelfAttorney
+SA11AIC00670364SA11AI.4532CANBoserBoserLMrs.830 White Farm RdIndianaPA15701G2018201806301078.0124292.66In-kind - Car Expenses - IRS rate @$0.55Pennsylvania State Higher EdProfessorH8PA09065BoserBoserLMrs.HPA15
+SA11AIC00670364SA11AI.4266INDBradwickFaye634 Willow AveIndianaPA15701P201820180429300.00400.00Check received at house partyRetiredRetired
+SA11AIC00670364SA11AI.4351INDBradyDavidMr.830 White Farm RdIndianaPA15701P20182018051550.001059.46In-kind - Snacks fo Election NightWescoDir Supply Chain
+SA11AIC00670364SA11AI.4353INDBradyDavidMr.830 White Farm RdIndianaPA15701G20182018051620.271079.73In-kind - Facebook adWescoDir Supply Chain
+SA11AIC00670364SA11AI.4411INDBradyDavidMr.830 White Farm RdIndianaPA15701G201820180608250.261329.99In-kind - WIX Email AccuntsWescoDir Supply Chain
+SA11AIC00670364SA11AI.4412INDBradyDavidMr.830 White Farm RdIndianaPA15701G20182018061224.991354.98In-kind - Facebook AdWescoDir Supply Chain
+SA11AIC00670364SA11AI.4413INDBradyDavidMr.830 White Farm RdIndianaPA15701G20182018061516.381371.36In-kind - Facebook AdWescoDir Supply Chain
+SA11AIC00670364SA11AI.4465INDBrownMargaret106 Sumar Rd.St. Mary'sPA15857G201820180626500.00500.00ACT BlueUniversity of PittsburghProfessor
+SA11AIC00670364SA11AI.4467INDBrownMargaret106 Sumar Rd.St. Mary'sPA15857G201820180626500.001000.00ACT BlueUniversity of PittsburghProfessor
+SA11AIC00670364SA11AI.4330INDFeldmanLarry649 Shryock Ave.IndianaPA15701G201820180520200.00250.00Act BlueRetiredRetired
+SA11AIC00670364SA11AI.4461INDHartleyHarold60 Stonehedge CircleBrookvillePA15825G201820180624250.00250.00ACT BlueRetiredRetired
+SA11AIC00670364SA11AI.4447INDIntemannGerald453 Cheese Run RoadIndianaPA15701G201820180617100.00250.00ACT BlueRetiredRetired
+SA11AIC00670364SA11AI.4254INDKlainMatthew1795 Barkley RdClarksburgPA15725P201820180428250.00250.00Check from home eventIRMCPhysician
+SA11AIC00670364SA11AI.4456INDLongStacy1900 Mumau RoadGlenn CampbellPA15742G201820180626208.00208.00In-kind - Graphic Design - LogoCats Up GraphicsOwner
+SA11AIC00670364SA11AI.4430INDPerlowCharles310 Grant StreetSuite 2500PittsburghPA15219G2018201806181000.001000.00Check received from CallsMcKnight Reality PartnersLawyer
+SA11AIC00670364SA11AI.4420INDRoseJonathan33 Katonah AveKatonahNY10536G2018201806012500.002500.00Check ReceivedSelfProperty Devleopment
+SA11AIC00670364SA11AI.4310INDSteelmanSarah220 N 6th StIndianaPA15701P201820180508500.00500.00Act BlueRetiredNone
+SA11AIC00670364SA11AI.4328INDSuttieJill988 Creston RoadBerkleyCA94708G201820180518250.00250.00Act BlueSelfWriter/editor
+SA11AIC00670364SA11AI.4444INDWheatleySusan1107 ray roadPenn RunPA15765G201820180616150.00250.00ACT BlueRetiredRetired
+SA11AIC00670364SA11AI.4497INDWheelerSarah870 Harvest LaneIndianaPA15701G201820180617500.00500.00Check ReceivedRetiredRetired
+SA11AIC00670364SA11AI.4432INDWilcoxMichel1172 Old Route 322CochrantonoPA16314G2018201806211000.001000.00Check received at Oil Region Rising eventRetiredRetired
+SA11CC00670364SA11C.4357PACIt Starts Today237 Florida Avenue NWWashingtonDC20001G2018201805233.373.37Check Received by MailC00630012It Starts Today
+SA11CC00670364SA11C.4359PACIt Starts Today237 Florida Avenue NWWashingtonDC20001G201820180523136.66140.03Check Received by MailC00630012It Starts Today
+SA11CC00670364SA11C.4360PACIt Starts Today237 Florida Avenue NWWashingtonDC20001G20182018052316.70156.73Check Received by MailC00630012It Starts Today
+SA11CC00670364SA11C.4361PACIt Starts Today237 Florida Avenue NWWashingtonDC20001G2018201805230.92157.65Check Received by MailC00630012It Starts Today
+SA11CC00670364SA11C.4362PACIt Starts Today237 Florida Avenue NWWashingtonDC20001G201820180523406.54564.19Check Received by MailC00630012It Starts Today
+SA11CC00670364SA11C.4524PACIt Starts Today237 Florida Avenue NWWashingtonDC20001G2018201806047.93572.12Received by MailC00630012It Starts Today
+SA11CC00670364SA11C.4422PACIt Starts Today237 Florida Avenue NWWashingtonDC20001G20182018061112.78584.90Check ReceiptC00630012It Starts Today
+SA11CC00670364SA11C.4523PACIt Starts Today237 Florida Avenue NWWashingtonDC20001G2018201806186.59591.49Received by MailC00630012It Starts Today
+SA11DC00670364SA11D.4364CANBoserBoserLMrs.830 White Farm RdIndianaPA15701G2018201805312714.6523214.65In-kind - Mileage at IRS rate for campaign travelPennsylvania State Higher EdProfessorH8PA09065BoserBoserLMrs.HPA15
+SA13AC00670364SA13A.4349CANBoserBoserLMrs.830 White Farm RdIndianaPA15701P2018201805022500.0016500.00Personal LoanPennsylvania State Higher EdProfessorH8PA09065BoserBoserLMrs.HPA15
+SA13AC00670364SA13A.4350CANBoserBoserLMrs.830 White Farm RdIndianaPA15701P2018201805034000.0020500.00Personal LoanPennsylvania State Higher EdProfessorH8PA09065BoserBoserLMrs.HPA15
+SB17C00670364SB17.4196ORGAmpersand Consulting4105 Penn AvenuePittsburghPA15224P2018201804277740.00Mail Piece preparation001C00670364Friends of Susan BoserHPA15
+SB17C00670364SB17.4201ORGAmpersand Consulting4105 Penn AvenuePittsburghPA15224P2018201805026824.62Postage - Mail piece004C00670364Friends of Susan BoserHPA15
+SB17C00670364SB17.4202ORGAmpersand Consulting4105 Penn AvenuePittsburghPA15224P2018201805033950.00Radio Advertising - Creation and Airtime004C00670364Friends of Susan BoserHPA15
+SB17C00670364SB17.4437ORGAmpersand Consulting4105 Penn AvenuePittsburghPA15224G2018201806056000.00Payment for Fund Raising Consulting003C00670364Friends of Susan BoserHPA15
+SB17C00670364SB17.4365CANBoserBoserLMrs.830 White Farm RdIndianaPA15701G2018201805312714.65In-kind - Mileage at IRS rate for campaign travelH8PA09065HPA15
+SB17C00670364SB17.4533CANBoserBoserLMrs.830 White Farm RdIndianaPA15701G2018201806301078.01In-kind - Car Expenses - IRS rate @$0.55H8PA09065HPA15
+SB17C00670364SB17.4416INDBradyDavidMr.830 White Farm RdIndianaPA15701G201820180608250.26In-kind - WIX Email Accunts
+SB17C00670364SB17.4415INDBradyDavidMr.830 White Farm RdIndianaPA15701G20182018061224.99In-kind - Facebook Ad
+SB17C00670364SB17.4414INDBradyDavidMr.830 White Farm RdIndianaPA15701G20182018061516.38In-kind - Facebook Ad
+SB17C00670364SB17.4199INDCampbellCallie123 Charles DriveCamillusNY13031P201820180429210.00Campaign Work Various001C00670364Friends of Susan BoserHPA15
+SB17C00670364SB17.4206INDCampbellCallie123 Charles DriveCamillusNY13031P201820180518160.00Campaign Work001C00670364Friends of Susan BoserHPA15
+SB17C00670364SB17.4204INDGuerraChelsea104 Greenview DriveIndianaPA15701P201820180515250.00Campaign Work001C00670364Friends of Susan BoserHPA15
+SB17C00670364SB17.4205INDHorvathElliePO Box 2Tire HillPA15959P201820180515840.00Campaign Work001C00670364Friends of Susan BoserHPA15
+SB17C00670364SB17.4458INDLongStacy1900 Mumau RoadGlenn CampbellPA15742G201820180626208.00In-kind - Graphic Design - Logo
+SB17C00670364SB17.4203ORGPrint and Copy Center731 Allegheny BlvdIndianaPA15701P201820180503179.76Printing004C00670364Friends of Susan BoserHPA15
+SB17C00670364SB17.4409ORGPrint and Copy Center731 Allegheny BlvdIndianaPA15701G201820180611873.12Literature and Buttons004C00670364Friends of Susan BoserHPA15
+SB17C00670364SB17.4207INDStenmanAmber415 Pearl StPittsburghPA15224P2018201805261600.00Campaign Work - Labor001C00670364Friends of Susan BoserHPA15
+SB17C00670364SB17.4496INDStenmanAmber415 Pearl StPittsburghPA15224G2018201806291516.67Campaign Manager - Contract Rate001C00670364Friends of Susan BoserHPA15
+SC/10C00670364SC/10.424513ACANBoserBoserLMrs.830 White Farm RdIndianaPA15701P20182000.000.002000.002018042112/31/20180.0000NYH8PA09065BoserBoserLMrs.HPA15
+SC/10C00670364SC/10.424713ACANBoserBoserLMrs.830 White Farm RdIndianaPA15701P201812000.000.0012000.002018042512/31/20180.0000NYH8PA09065BoserBoserLMrs.HPA15
+SC/10C00670364SC/10.434913ACANBoserBoserLMrs.830 White Farm RdIndianaPA15701P20182500.000.002500.002018050212/31/20180.0000NYH8PA09065BoserBoserLMrs.HPA15
+SC/10C00670364SC/10.435013ACANBoserBoserLMrs.830 White Farm RdIndianaPA15701P20184000.000.004000.002018050312/31/20180.0000NYH8PA09065BoserBoserLMrs.HPA15

--- a/spec/filing_spec.rb
+++ b/spec/filing_spec.rb
@@ -27,6 +27,8 @@ describe Fech::Filing do
     @filing_special_character.stubs(:file_path).returns(File.join(File.dirname(__FILE__), 'data', '771694.fec'))
     @filing_f99 = Fech::Filing.new(862554)
     @filing_f99.stubs(:file_path).returns(File.join(File.dirname(__FILE__), 'data', '862554.fec'))
+    @filing_encoding = Fech::Filing.new(1247604)
+    @filing_encoding.stubs(:file_path).returns(File.join(File.dirname(__FILE__), 'data', '1247604.fec'))
   end
 
   describe "#filing_version" do
@@ -83,6 +85,7 @@ describe Fech::Filing do
       sum_f13[:form_type].should == 'F13N'
       sum_filing_special_character = @filing_special_character.summary
       sum_filing_special_character[:form_type].should == "F3XN"
+      expect{@filing_encoding.summary}.to_not raise_error
     end
   end
 


### PR DESCRIPTION
The `@encoding` instance variable on a `Filing` object is ignored in methods such as 
`Filing#form_type`, which can lead to an `ArgumentError` ("invalid byte sequence in UTF-8"). Before the included change in `lib/fech/filing.rb` is made, the included test case demonstrates such an error when we try to call `Filing#summary`.

This change takes `@encoding` into account when reading the filing from disk, which avoids the `ArgumentError`.

(The entire test suite now only has two failing tests, both of which are addressed in #83 and don't appear to be related to this specific change.)